### PR TITLE
Move to dependency injection-based API

### DIFF
--- a/src/ReactPrimitivesArt.js
+++ b/src/ReactPrimitivesArt.js
@@ -1,0 +1,47 @@
+const ReactPrimitivesArt = {
+  LinearGradient: null,
+  RadialGradient: null,
+  Pattern: null,
+  Transform: null,
+  Path: null,
+  Surface: null,
+  Group: null,
+  ClippingRectangle: null,
+  Shape: null,
+  Text: null,
+
+  inject(api) {
+    if (api.LinearGradient) {
+      ReactPrimitivesArt.LinearGradient = api.LinearGradient;
+    }
+    if (api.RadialGradient) {
+      ReactPrimitivesArt.RadialGradient = api.RadialGradient;
+    }
+    if (api.Pattern) {
+      ReactPrimitivesArt.Pattern = api.Pattern;
+    }
+    if (api.Transform) {
+      ReactPrimitivesArt.Transform = api.Transform;
+    }
+    if (api.Path) {
+      ReactPrimitivesArt.Path = api.Path;
+    }
+    if (api.Surface) {
+      ReactPrimitivesArt.Surface = api.Surface;
+    }
+    if (api.Group) {
+      ReactPrimitivesArt.Group = api.Group;
+    }
+    if (api.ClippingRectangle) {
+      ReactPrimitivesArt.ClippingRectangle = api.ClippingRectangle;
+    }
+    if (api.Shape) {
+      ReactPrimitivesArt.Shape = api.Shape;
+    }
+    if (api.Text) {
+      ReactPrimitivesArt.Text = api.Text;
+    }
+  }
+};
+
+module.exports = ReactPrimitivesArt;

--- a/src/core.android.js
+++ b/src/core.android.js
@@ -1,27 +1,3 @@
-import { ART } from 'react-native';
+require("./injection/react-native");
 
-const {
-  ClippingRectangle,
-  Group,
-  LinearGradient,
-  Path,
-  Pattern,
-  RadialGradient,
-  Shape,
-  Surface,
-  Text,
-  Transform,
-} = ART;
-
-module.exports = {
-  ClippingRectangle,
-  Group,
-  LinearGradient,
-  Path,
-  Pattern,
-  RadialGradient,
-  Shape,
-  Surface,
-  Text,
-  Transform,
-};
+module.exports = require("./ReactPrimitivesArt");

--- a/src/core.ios.js
+++ b/src/core.ios.js
@@ -1,27 +1,3 @@
-import { ART } from 'react-native';
+require("./injection/react-native");
 
-const {
-  ClippingRectangle,
-  Group,
-  LinearGradient,
-  Path,
-  Pattern,
-  RadialGradient,
-  Shape,
-  Surface,
-  Text,
-  Transform,
-} = ART;
-
-module.exports = {
-  ClippingRectangle,
-  Group,
-  LinearGradient,
-  Path,
-  Pattern,
-  RadialGradient,
-  Shape,
-  Surface,
-  Text,
-  Transform,
-};
+module.exports = require("./ReactPrimitivesArt");

--- a/src/core.js
+++ b/src/core.js
@@ -1,0 +1,3 @@
+require("./injection/react-art");
+
+module.exports = require("./ReactPrimitivesArt");

--- a/src/core.web.js
+++ b/src/core.web.js
@@ -1,25 +1,3 @@
-import {
-  ClippingRectangle,
-  Group,
-  LinearGradient,
-  Path,
-  Pattern,
-  RadialGradient,
-  Shape,
-  Surface,
-  Text,
-  Transform,
-} from 'react-art';
+require("./injection/react-art");
 
-module.exports = {
-  ClippingRectangle,
-  Group,
-  LinearGradient,
-  Path,
-  Pattern,
-  RadialGradient,
-  Shape,
-  Surface,
-  Text,
-  Transform,
-};
+module.exports = require("./ReactPrimitivesArt");

--- a/src/injection/react-art.js
+++ b/src/injection/react-art.js
@@ -1,0 +1,26 @@
+const ReactPrimitivesArt = require("../ReactPrimitivesArt");
+import {
+  ClippingRectangle,
+  Group,
+  LinearGradient,
+  Path,
+  Pattern,
+  RadialGradient,
+  Shape,
+  Surface,
+  Text,
+  Transform,
+} from 'react-art';
+
+ReactPrimitivesArt.inject({
+  ClippingRectangle,
+  Group,
+  LinearGradient,
+  Path,
+  Pattern,
+  RadialGradient,
+  Shape,
+  Surface,
+  Text,
+  Transform,
+});

--- a/src/injection/react-native.js
+++ b/src/injection/react-native.js
@@ -1,0 +1,28 @@
+const ReactPrimitivesArt = require("../ReactPrimitivesArt");
+import { ART } from 'react-native';
+
+const {
+  ClippingRectangle,
+  Group,
+  LinearGradient,
+  Path,
+  Pattern,
+  RadialGradient,
+  Shape,
+  Surface,
+  Text,
+  Transform,
+} = ART;
+
+ReactPrimitivesArt.inject({
+  ClippingRectangle,
+  Group,
+  LinearGradient,
+  Path,
+  Pattern,
+  RadialGradient,
+  Shape,
+  Surface,
+  Text,
+  Transform,
+});


### PR DESCRIPTION
This is closer to the base `react-primitives` implementation, and will allow me to use a [forked version of `react-art`](https://github.com/reactjs/react-art/issues/113#issuecomment-273333135).